### PR TITLE
Define the RTC object ourselves (lib v2.0)

### DIFF
--- a/WordClock.ino
+++ b/WordClock.ino
@@ -74,6 +74,7 @@ int x = matrix.width();
 int pass = 0;
 uint32_t z = 0;
 char disp_str[20];
+DS3232RTC RTC;
 
 // ISR code to read LDR and respond to brightness changes
 ISR(TIMER1_COMPA_vect) // interrupt 10Hz on Timer 1


### PR DESCRIPTION
DS3232 lib v2.0 does not define the RTC object anymore. So we have to do that ourselves :(
See https://github.com/JChristensen/DS3232RTC.